### PR TITLE
Revise authenticator min cardinality : make it optional

### DIFF
--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -49,7 +49,6 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * author only Reference(AsPractitionerRoleProfile or Device or FRCorePatientProfile)
 
 * authenticator MS // Authenticator contained dans le profil MHD
-* authenticator 1..
 * authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents. Si l’auteur est un dispositif, cet attribut doit représenter la personne responsable de l’action effectuée par le dispositif. Pour les documents d’expression personnelle du patient, cet attribut fait référence au patient." 
 * authenticator only Reference(AsPractitionerRoleProfile or AsOrganizationProfile)
 

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -48,8 +48,8 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * author 1..
 * author only Reference(AsPractitionerRoleProfile or Device or FRCorePatientProfile)
 
-* authenticator MS // Authenticator contained dans le profil MHD
-* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents. Si l’auteur est un dispositif, cet attribut doit représenter l'organisation responsable de l’action effectuée par le dispositif. L'authenticator DOIT être renseigné, sauf dans le cas où le document est une expression personnelle du patient, auquel cas l'authenticator doit rester vide." 
+* authenticator MS
+* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents."
 * authenticator only Reference(AsPractitionerRoleProfile or AsOrganizationProfile)
 
 * relatesTo MS

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -49,7 +49,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * author only Reference(AsPractitionerRoleProfile or Device or FRCorePatientProfile)
 
 * authenticator MS // Authenticator contained dans le profil MHD
-* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents. Si l’auteur est un dispositif, cet attribut doit représenter l'organisation responsable de l’action effectuée par le dispositif. Dans le cas où le document est poussé par le patient, l'authenticator doit rester vide." 
+* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents. Si l’auteur est un dispositif, cet attribut doit représenter l'organisation responsable de l’action effectuée par le dispositif. L'authenticator DOIT être renseigné, sauf dans le cas où le document est une expression personnelle du patient, auquel cas l'authenticator doit rester vide." 
 * authenticator only Reference(AsPractitionerRoleProfile or AsOrganizationProfile)
 
 * relatesTo MS

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -46,11 +46,12 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * author MS // Author contained dans le profil MHD
 * author ^short = "Personnes physiques ou morales et/ou les dispositifs auteurs d'un document."
 * author 1..
-* author only Reference(AsPractitionerRoleProfile or Device or FRCorePatientProfile)
+* author only Reference(AsPractitionerProfile or AsPractitionerRoleProfile or Device or FRCorePatientProfile)
+
 
 * authenticator MS
 * authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents."
-* authenticator only Reference(AsPractitionerRoleProfile or AsOrganizationProfile)
+* authenticator only Reference(AsPractitionerProfile or AsPractitionerRoleProfile or AsOrganizationProfile)
 
 * relatesTo MS
 * relatesTo ^definition = "Cardinalité contrainte à [1..1] lorsque le flux envoyé correspond au remplacement d’un document."

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -49,7 +49,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * author only Reference(AsPractitionerRoleProfile or Device or FRCorePatientProfile)
 
 * authenticator MS // Authenticator contained dans le profil MHD
-* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents. Si l’auteur est un dispositif, cet attribut doit représenter la personne responsable de l’action effectuée par le dispositif. Pour les documents d’expression personnelle du patient, cet attribut fait référence au patient." 
+* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents. Si l’auteur est un dispositif, cet attribut doit représenter l'organisation responsable de l’action effectuée par le dispositif. Dans le cas où le document est poussé par le patient, l'authenticator doit rester vide." 
 * authenticator only Reference(AsPractitionerRoleProfile or AsOrganizationProfile)
 
 * relatesTo MS

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -46,7 +46,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 
 * authenticator MS
 * authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents."
-* authenticator only Reference(AsPractitionerRoleProfile or AsOrganizationProfile)
+* authenticator only Reference(AsPractitionerProfile or AsPractitionerRoleProfile or AsOrganizationProfile)
 
 * description MS
 * description ^short = "Commentaire associé au document."

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -45,8 +45,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 
 
 * authenticator MS
-* authenticator 0..1
-* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents. Si l’auteur est un dispositif, cet attribut doit représenter la personne responsable de l’action effectuée par le dispositif."
+* authenticator ^short = "Cet attribut représente l’acteur validant le document et prenant la responsabilité du contenu médical de celui-ci. Il peut s’agir de l’auteur du document si celui-ci est une personne et s’il endosse la responsabilité du contenu médical de ses documents."
 * authenticator only Reference(AsPractitionerRoleProfile or AsOrganizationProfile)
 
 * description MS


### PR DESCRIPTION
## Description des changements

* [Discussion du 27 mai] - se rappeler de l'origine de la PR

Selon la spec, contrainte sur l'authenticator : "Si l’auteur est un dispositif, cet attribut doit représenter la personne responsable de l’action effectuée par le dispositif. "

<img width="1155" height="114" alt="image" src="https://github.com/user-attachments/assets/f024e54c-3768-4eb6-a7c2-61eb9632c7f5" />


Cependant, l'authenticator ne peut pas être un patient par exemple dans le cadre de MonEspaceSanté.

Référence limitée à [Practitioner](http://hl7.org/fhir/R4/practitioner.html) | [PractitionerRole](http://hl7.org/fhir/R4/practitionerrole.html) | [Organization](http://hl7.org/fhir/R4/organization.html) dans MHD
<img width="856" height="43" alt="image" src="https://github.com/user-attachments/assets/109c2735-471b-4e48-81d7-01989cbfdf96" />

Ainsi, dans ce cas, il n'y a pas forcément d'authenticator dans le cadre de MES (sauf si c'est l'Organization représentant le SNR ?)

## Preview

https://ansforge.github.io/IG-fhir-partage-de-documents-de-sante/nriss-patch-2/ig

## Impact API MES
