### PR TITLE
Update card custodian

### DIFF
--- a/input/fsh/Examples/DR_comprehensive.fsh
+++ b/input/fsh/Examples/DR_comprehensive.fsh
@@ -19,6 +19,8 @@ Usage: #example
 
 * date = "2025-04-29T12:00:00+01:00"
 
+* custodian = Reference(org-example)
+
 * author = Reference(practitionerrole-example)
 
 * authenticator = Reference(org-example)

--- a/input/fsh/Examples/DR_simplified.fsh
+++ b/input/fsh/Examples/DR_simplified.fsh
@@ -16,6 +16,8 @@ Usage: #example
 
 * date = "2025-04-30T09:30:00+01:00"
 
+* custodian = Reference(org-example)
+
 * author[0] = Reference(practitionerrole-example)
 * authenticator = Reference(practitionerrole-example)
 

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -41,8 +41,8 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * subject ^short = "Référence vers le patient concerné par le document. Cette même ressource est référencée depuis context.sourcePatientInfo."
 
 * custodian 1..
-* custodian ^short = "Organisme responsable de la gestion du document. Information transmise dans le VIHF."
-
+* custodian ^short = "Organisme responsable de la gestion du document. Dans le cadre XDS, il s'agit d'une information transmise dans le VIHF."
+* custodian ^definition = "Correspond à l’organisation responsable de la conservation, de la maintenance et/ou de l’accès au document, et non nécessairement à l’auteur ou à l’hébergeur technique."
 * date MS
 * date ^short = "Représente la date de création de la ressource DocumentReference dans FHIR"
 

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -40,6 +40,9 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * subject MS
 * subject ^short = "Référence vers le patient concerné par le document. Cette même ressource est référencée depuis context.sourcePatientInfo."
 
+* custodian 1..
+* custodian ^short = "Organisme responsable de la gestion du document. Information transmise dans le VIHF."
+
 * date MS
 * date ^short = "Représente la date de création de la ressource DocumentReference dans FHIR"
 

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -33,6 +33,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 
 * custodian 1..
 * custodian ^short = "Organisme responsable de la gestion du document. Dans le cadre XDS, il s'agit d'une information transmise dans le VIHF."
+* custodian ^definition = "Correspond à l’organisation responsable de la conservation, de la maintenance et/ou de l’accès au document, et non nécessairement à l’auteur ou à l’hébergeur technique."
 
 * subject 1..1
 * subject ^short = "Patient concerné par ce document. La ressource référencée peut être présente sous l’élément DocumentReference.contained ou via le champ identifier."

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -32,7 +32,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * category obeys constr-bind-category
 
 * custodian 1..
-* custodian ^short = "Organisme responsable de la gestion du document. Information transmise dans le VIHF."
+* custodian ^short = "Organisme responsable de la gestion du document. Dans le cadre XDS, il s'agit d'une information transmise dans le VIHF."
 
 * subject 1..1
 * subject ^short = "Patient concerné par ce document. La ressource référencée peut être présente sous l’élément DocumentReference.contained ou via le champ identifier."

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -31,6 +31,9 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * category ^short = "Représente la classe du document (compte rendu, imagerie médicale, traitement, certificat,...)."
 * category obeys constr-bind-category
 
+* custodian 1..
+* custodian ^short = "Organisme responsable de la gestion du document. Information transmise dans le VIHF."
+
 * subject 1..1
 * subject ^short = "Patient concerné par ce document. La ressource référencée peut être présente sous l’élément DocumentReference.contained ou via le champ identifier."
 * subject only Reference(FRCorePatientProfile) 


### PR DESCRIPTION
## Description des changements

voir issue #107 

## Preview

https://ansforge.github.io/IG-fhir-partage-de-documents-de-sante/cp-card-custodian/ig

## Impact API MES

Custodian n'est pas utilisé dans le cadre du MES actuellement. Il peut facilement être complété en mettant une référence vers l'owner du device.