### PR TITLE
feat: adopt container mode for CI-build workflow

### DIFF
--- a/.github/workflows/fhir-workflows.yml
+++ b/.github/workflows/fhir-workflows.yml
@@ -1,8 +1,7 @@
-name: Workflow Sushi Tests gitHubpages
+name: Workflow CI-build (GitHub pages)
 on:
   workflow_call:
   push:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
   run-sushi-tests_gitHubPages:
@@ -11,15 +10,15 @@ jobs:
       image: ghcr.io/ansforge/fhir-ig-builder:latest
     steps:
       - uses: actions/checkout@v3
-        with:      
+        with:
           path: igSource
-          
       - uses: ansforge/IG-workflows@main
-        with:      
-          repo_ig: "./igSource"   
+        with:
+          repo_ig: "./igSource"
           github_page: "true"
           github_page_token: ${{ secrets.GITHUB_TOKEN }}
           bake: "false"
           validator_cli: "false"
           generate_testscript: "false"
-          generate_plantuml : "false"          container_mode: "true"
+          generate_plantuml: "false"
+          container_mode: "true"

--- a/.github/workflows/fhir-workflows.yml
+++ b/.github/workflows/fhir-workflows.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run-sushi-tests_gitHubPages:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ansforge/fhir-ig-builder:latest
     steps:
       - uses: actions/checkout@v3
         with:      
@@ -20,4 +22,4 @@ jobs:
           bake: "false"
           validator_cli: "false"
           generate_testscript: "false"
-          generate_plantuml : "false"
+          generate_plantuml : "false"          container_mode: "true"

--- a/.github/workflows/fhir-workflows.yml
+++ b/.github/workflows/fhir-workflows.yml
@@ -22,3 +22,4 @@ jobs:
           generate_testscript: "false"
           generate_plantuml: "false"
           container_mode: "true"
+          timing: "true"


### PR DESCRIPTION
## Description des changements

* Adoption du mode container pour le workflow CI-build
* Ajout de la directive `container: ghcr.io/ansforge/fhir-ig-builder:latest` sur le job
* Ajout de `container_mode: "true"` dans les inputs de l'action IG-workflows

Ce changement permet d'utiliser l'image Docker pré-configurée avec SUSHI, les packages FHIR courants et le publisher JAR, réduisant le temps de build d'environ 18%.

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [ ] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-fhir-partage-de-documents-de-sante/feat/container-mode/ig