### PR TITLE
Slicing de DocumentReference.securityLabel (confidentiality/visibilityStatus)

### DIFF
--- a/input/fsh/Examples/DR_comprehensive.fsh
+++ b/input/fsh/Examples/DR_comprehensive.fsh
@@ -27,7 +27,7 @@ Usage: #example
 
 * description = "Compte rendu d’hospitalisation suite à une chirurgie."
 
-* securityLabel = https://mos.esante.gouv.fr/NOS/TRE_A07-StatusVisibiliteDocument/FHIR/TRE-A07-StatusVisibiliteDocument#N "Normal"
+* securityLabel[confidentiality] = http://terminology.hl7.org/CodeSystem/v3-Confidentiality#N "Normal"
 
 * content[0].attachment.contentType = #application/pdf
 * content[0].attachment.language = #fr-FR

--- a/input/fsh/Examples/DR_simplified.fsh
+++ b/input/fsh/Examples/DR_simplified.fsh
@@ -23,6 +23,8 @@ Usage: #example
 
 * description = "Note d'évolution suite à une consultation de suivi."
 
+* securityLabel[confidentiality] = http://terminology.hl7.org/CodeSystem/v3-Confidentiality#N "Normal"
+
 * content.attachment.contentType = #application/pdf
 * content.attachment.language = #fr-FR
 * content.attachment.data = "SGVsbG8gV29ybGQ="

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -73,14 +73,13 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel (pattern sur coding.system) pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
+* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : confidentiality est discriminée par son required binding (ValueSet fermé v3-ConfidentialityClassification), visibilityStatus par un pattern sur coding.system (JDV_J110-StatutVisibiliteDocument-CISIS)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
-* securityLabel[confidentiality] ^patternCodeableConcept.coding[0].system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -83,7 +83,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS
-* securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
+* securityLabel[visibilityStatus] ^short = "Statut de visibilité du document (invisible patient, invisible représentants légaux, masqué PS, etc...)."
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -73,7 +73,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : confidentiality est discriminée par son required binding (ValueSet fermé v3-ConfidentialityClassification), visibilityStatus par un pattern sur coding.system (JDV_J110-StatutVisibiliteDocument-CISIS)"
+* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : chaque slice est discriminée par son required binding sur un ValueSet fermé (v3-ConfidentialityClassification pour confidentiality, JDV_J110-StatutVisibiliteDocument-CISIS pour visibilityStatus)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
@@ -84,7 +84,6 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 
 * securityLabel[visibilityStatus] MS
 * securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
-* securityLabel[visibilityStatus] ^patternCodeableConcept.coding[0].system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -70,7 +70,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * description MS
 * description ^short = "Description du document source, lisible par l'homme, correspondant au commentaire associé au document"
 
-* securityLabel ^slicing.discriminator.type = #pattern
+* securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
 * securityLabel ^slicing.description = "Slice sur securityLabel (pattern sur coding.system) pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -70,8 +70,21 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * description MS
 * description ^short = "Description du document source, lisible par l'homme, correspondant au commentaire associé au document"
 
-* securityLabel from https://mos.esante.gouv.fr/NOS/JDV_J08-XdsConfidentialityCode-CISIS/FHIR/JDV-J08-XdsConfidentialityCode-CISIS (extensible)
+* securityLabel ^slicing.discriminator.type = #value
+* securityLabel ^slicing.discriminator.path = "coding.system"
+* securityLabel ^slicing.rules = #open
+* securityLabel ^slicing.description = "Slice sur securityLabel.coding.system pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
+
+* securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
+
+* securityLabel[confidentiality] MS
+* securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
+* securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
+
+* securityLabel[visibilityStatus] MS
+* securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
+* securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########
 // # CONTENT #

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -73,7 +73,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : chaque slice est discriminée par son required binding sur un ValueSet fermé (v3-ConfidentialityClassification pour confidentiality, JDV_J110-StatutVisibiliteDocument-CISIS pour visibilityStatus)"
+* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (U, L, M, N, R, V) du statut de visibilité (MASQUE_PS, INVISIBLE_PATIENT, etc...) : chaque slice est discriminée par son required binding sur un ValueSet fermé (v3-ConfidentialityClassification pour confidentiality, JDV_J110-StatutVisibiliteDocument-CISIS pour visibilityStatus)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -70,22 +70,22 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * description MS
 * description ^short = "Description du document source, lisible par l'homme, correspondant au commentaire associé au document"
 
-* securityLabel ^slicing.discriminator.type = #value
-* securityLabel ^slicing.discriminator.path = "coding.system"
+* securityLabel ^slicing.discriminator.type = #pattern
+* securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel.coding.system pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
+* securityLabel ^slicing.description = "Slice sur securityLabel (pattern sur coding.system) pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
-* securityLabel[confidentiality].coding.system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
+* securityLabel[confidentiality] ^patternCodeableConcept.coding[0].system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS
 * securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
-* securityLabel[visibilityStatus].coding.system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
+* securityLabel[visibilityStatus] ^patternCodeableConcept.coding[0].system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -80,10 +80,12 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
+* securityLabel[confidentiality].coding.system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS
 * securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
+* securityLabel[visibilityStatus].coding.system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -79,8 +79,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
 
 * securityLabel[confidentiality] MS
-* securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
-* securityLabel[confidentiality] ^definition = "En l'absence d'information de confidentialité disponible, la valeur par défaut à utiliser est N (Normal), conformément à ce qui est déjà pratiqué aujourd'hui pour les documents CDA."
+* securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint, ...). En l'absence d'information de confidentialité disponible, la valeur par défaut à utiliser est N (Normal), conformément à ce qui est déjà pratiqué aujourd'hui pour les documents CDA."
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS

--- a/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
+++ b/input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh
@@ -80,6 +80,7 @@ Description: "Profil contenant les métadonnées du document ainsi que le lien v
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
+* securityLabel[confidentiality] ^definition = "En l'absence d'information de confidentialité disponible, la valeur par défaut à utiliser est N (Normal), conformément à ce qui est déjà pratiqué aujourd'hui pour les documents CDA."
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -69,22 +69,22 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * description MS
 * description ^short = "Commentaire associé au document."
 
-* securityLabel ^slicing.discriminator.type = #value
-* securityLabel ^slicing.discriminator.path = "coding.system"
+* securityLabel ^slicing.discriminator.type = #pattern
+* securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel.coding.system pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
+* securityLabel ^slicing.description = "Slice sur securityLabel (pattern sur coding.system) pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
-* securityLabel[confidentiality].coding.system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
+* securityLabel[confidentiality] ^patternCodeableConcept.coding[0].system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS
 * securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
-* securityLabel[visibilityStatus].coding.system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
+* securityLabel[visibilityStatus] ^patternCodeableConcept.coding[0].system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -72,7 +72,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : confidentiality est discriminée par son required binding (ValueSet fermé v3-ConfidentialityClassification), visibilityStatus par un pattern sur coding.system (JDV_J110-StatutVisibiliteDocument-CISIS)"
+* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : chaque slice est discriminée par son required binding sur un ValueSet fermé (v3-ConfidentialityClassification pour confidentiality, JDV_J110-StatutVisibiliteDocument-CISIS pour visibilityStatus)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
@@ -83,7 +83,6 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 
 * securityLabel[visibilityStatus] MS
 * securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
-* securityLabel[visibilityStatus] ^patternCodeableConcept.coding[0].system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -79,6 +79,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
+* securityLabel[confidentiality] ^definition = "En l'absence d'information de confidentialité disponible, la valeur par défaut à utiliser est N (Normal), conformément à ce qui est déjà pratiqué aujourd'hui pour les documents CDA."
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -72,14 +72,13 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel (pattern sur coding.system) pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
+* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : confidentiality est discriminée par son required binding (ValueSet fermé v3-ConfidentialityClassification), visibilityStatus par un pattern sur coding.system (JDV_J110-StatutVisibiliteDocument-CISIS)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
-* securityLabel[confidentiality] ^patternCodeableConcept.coding[0].system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -69,7 +69,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * description MS
 * description ^short = "Commentaire associé au document."
 
-* securityLabel ^slicing.discriminator.type = #pattern
+* securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
 * securityLabel ^slicing.description = "Slice sur securityLabel (pattern sur coding.system) pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -82,7 +82,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS
-* securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
+* securityLabel[visibilityStatus] ^short = "Statut de visibilité du document (invisible patient, invisible représentants légaux, masqué PS, etc...)."
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -78,8 +78,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
 
 * securityLabel[confidentiality] MS
-* securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
-* securityLabel[confidentiality] ^definition = "En l'absence d'information de confidentialité disponible, la valeur par défaut à utiliser est N (Normal), conformément à ce qui est déjà pratiqué aujourd'hui pour les documents CDA."
+* securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint, ...). En l'absence d'information de confidentialité disponible, la valeur par défaut à utiliser est N (Normal), conformément à ce qui est déjà pratiqué aujourd'hui pour les documents CDA."
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -72,7 +72,7 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * securityLabel ^slicing.discriminator.type = #value
 * securityLabel ^slicing.discriminator.path = "$this"
 * securityLabel ^slicing.rules = #open
-* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07) : chaque slice est discriminée par son required binding sur un ValueSet fermé (v3-ConfidentialityClassification pour confidentiality, JDV_J110-StatutVisibiliteDocument-CISIS pour visibilityStatus)"
+* securityLabel ^slicing.description = "Slice sur securityLabel pour distinguer le niveau de confidentialité (U, L, M, N, R, V) du statut de visibilité (MASQUE_PS, INVISIBLE_PATIENT, etc...) : chaque slice est discriminée par son required binding sur un ValueSet fermé (v3-ConfidentialityClassification pour confidentiality, JDV_J110-StatutVisibiliteDocument-CISIS pour visibilityStatus)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
 
 * securityLabel contains confidentiality 1..1 and visibilityStatus 0..*

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -79,10 +79,12 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 
 * securityLabel[confidentiality] MS
 * securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
+* securityLabel[confidentiality].coding.system = "http://terminology.hl7.org/CodeSystem/v3-Confidentiality"
 * securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
 
 * securityLabel[visibilityStatus] MS
 * securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
+* securityLabel[visibilityStatus].coding.system = "https://mos.esante.gouv.fr/NOS/TRE_A07-StatutVisibiliteDocument/FHIR/TRE-A07-StatutVisibiliteDocument"
 * securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########

--- a/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
+++ b/input/fsh/profiles/PDSm_SimplifiedPublish.fsh
@@ -69,8 +69,21 @@ La publication simplifiée est une simple requête HTTP POST d'une ressource Doc
 * description MS
 * description ^short = "Commentaire associé au document."
 
-* securityLabel from https://mos.esante.gouv.fr/NOS/JDV_J08-XdsConfidentialityCode-CISIS/FHIR/JDV-J08-XdsConfidentialityCode-CISIS (extensible)
+* securityLabel ^slicing.discriminator.type = #value
+* securityLabel ^slicing.discriminator.path = "coding.system"
+* securityLabel ^slicing.rules = #open
+* securityLabel ^slicing.description = "Slice sur securityLabel.coding.system pour distinguer le niveau de confidentialité (NRV) du statut de visibilité complémentaire (TRE A07)"
 * securityLabel ^short = "Contient les informations définissant le niveau de confidentialité d'un document."
+
+* securityLabel contains confidentiality 1..1 and visibilityStatus 0..*
+
+* securityLabel[confidentiality] MS
+* securityLabel[confidentiality] ^short = "Niveau de confidentialité standard du document (Normal, Restreint, Très restreint)."
+* securityLabel[confidentiality] from http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification (required)
+
+* securityLabel[visibilityStatus] MS
+* securityLabel[visibilityStatus] ^short = "Statut de visibilité complémentaire du document (motifs de masquage patient, représentants légaux, professionnels)."
+* securityLabel[visibilityStatus] from $JDV-J110-StatutVisibiliteDocument-CISIS (required)
 
 // ###########
 // # CONTENT #


### PR DESCRIPTION
## Description des changements

* [`input/fsh/profiles/PDSm_ComprehensiveDocumentReference.fsh`] Remplacement du binding `extensible` unique sur `JDV_J08-XdsConfidentialityCode-CISIS` par un slicing sur `securityLabel` (discriminator `value` sur `$this`, `rules = open`), avec deux slices : `confidentiality` (`1..1`, `required` sur `http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification`) et `visibilityStatus` (`0..*`, `required` sur `JDV_J110-StatutVisibiliteDocument-CISIS`). Les deux slices sont discriminées uniquement par leur `required` binding respectif — chacun pointe vers un ValueSet fermé/énuméré dont les codes ne se recoupent pas, ce qui suffit à lever toute ambiguïté sans avoir besoin de fixer un `pattern`/`fixed` supplémentaire (cf. spec FHIR R4 sur le discriminator `value`, déterminé par `fixed[x]`, `pattern[x]` **ou** un required binding énuméré).
* [`input/fsh/profiles/PDSm_SimplifiedPublish.fsh`] Même slicing appliqué (structure `securityLabel` identique dans ce profil).
* [`input/fsh/Examples/DR_comprehensive.fsh`] Correction de l'exemple : l'ancienne valeur `securityLabel` référençait un système erroné et mélangeait les deux axes ; utilise maintenant `securityLabel[confidentiality]` avec le code `N` (Normal) sur `v3-Confidentiality`.
* [`input/fsh/Examples/DR_simplified.fsh`] Ajout de `securityLabel[confidentiality]`, absent jusqu'ici et désormais requis par le slicing (cardinalité `1..1`).

Closes #123

## Preview

https://ansforge.github.io/IG-fhir-partage-de-documents-de-sante/nr-securitylabel-slicing-123/ig

## Impact API MES

Le niveau de confidentialité devient obligatoire pour le simplified publish


Modification proposée suite à la discussion du 6 août 2026 avec @ypoiron et @aperie07 dans le cadre de la revue HL7 EU PS