### PR TITLE
Aligner le workflow CI-build sur IG-modele et repasser en ci-build

### DIFF
--- a/.github/workflows/fhir-workflows.yml
+++ b/.github/workflows/fhir-workflows.yml
@@ -3,6 +3,13 @@ on:
   workflow_call:
   push:
   workflow_dispatch:
+
+# Annule tout run ci-build précédent encore en cours sur la même branche/PR
+# dès qu'un nouveau push arrive, pour économiser des minutes GitHub Actions.
+concurrency:
+  group: ci-build-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-sushi-tests_gitHubPages:
     runs-on: ubuntu-latest
@@ -22,4 +29,3 @@ jobs:
           generate_testscript: "false"
           generate_plantuml: "false"
           container_mode: "true"
-          timing: "true"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -11,7 +11,7 @@ status: active
 version: 3.1.1
 fhirVersion: 4.0.1
 copyrightYear: 2020+
-releaseLabel: trial-use
+releaseLabel: ci-build
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 dependencies:


### PR DESCRIPTION
## Description des changements

* Aligne `.github/workflows/fhir-workflows.yml` sur le workflow de référence `ansforge/IG-modele` : ajout d'un `concurrency` group pour annuler les runs redondants, retrait du paramètre `timing` devenu obsolète.
* Passe `sushi-config.yaml` > `releaseLabel` de `trial-use` à `ci-build` pour reprendre le développement après la release 3.1.1 (le `status` sushi-config reste volontairement à `active`).

## Preview

https://ansforge.github.io/IG-fhir-partage-de-documents-de-sante/nr-ci-build-workflow/ig

## Impact API MES

Aucun — changement de workflow CI et de métadonnées de release uniquement, pas de changement de contenu FHIR.